### PR TITLE
UX updates

### DIFF
--- a/app/controllers/coffees_controller.rb
+++ b/app/controllers/coffees_controller.rb
@@ -78,7 +78,7 @@ class CoffeesController < ApplicationController
 
   def search
     Coffee.where('name ILIKE :search OR tasting_notes ILIKE :search OR country ILIKE :search OR process ILIKE :search',
-                 search: "%#{params[:query].downcase}%")
+                 search: "%#{params[:query].downcase.strip}%")
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/roasters_controller.rb
+++ b/app/controllers/roasters_controller.rb
@@ -72,7 +72,7 @@ class RoastersController < ApplicationController
   private
 
   def search
-    pagy(Roaster.where('name ILIKE :search', search: "%#{params[:query].downcase}%"), items: 10)
+    pagy(Roaster.where('name ILIKE :search', search: "%#{params[:query].downcase.strip}%"), items: 10)
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/views/admin/_users_table.html.erb
+++ b/app/views/admin/_users_table.html.erb
@@ -10,6 +10,7 @@
     <td><%= user.favourites_count %></td>
     <td><%= user.brews_count %></td>
     <td><%= user.public_brews_count %></td>
+    <td><%= user.sign_in_count %></td>
     <td><%= user.current_sign_in_at.present? ? "#{time_ago_in_words(user.current_sign_in_at)} ago" : "Never" %></td>
   </tr>
 <% end %>

--- a/app/views/dashboard/_no_brews.html.erb
+++ b/app/views/dashboard/_no_brews.html.erb
@@ -1,0 +1,36 @@
+<div class="brew-row row">
+  <div class="td">
+    <h5>You haven't logged any brews yet.</h5>
+  </div>
+</div>
+<hr>
+<div class="brew-row row">
+  <div class="td">
+    <h5> Add a coffee to your shelf and click " Make a Brew <i class="icon-basic-coffee-cup-3"></i> " to log
+      your first brew.</h5>
+  </div>
+</div>
+<hr>
+<div class="brew-row row">
+  <div class="td coffee-name">
+    <h5>
+      Example Coffee
+    </h5>
+  </div>
+  <div class="td equipment desktop">E.g. V60</div>
+  <div class="td row ratio">
+    <div class="data"><i class="icon-basic-coffee-beans-4"></i>15g</div>
+    <div class="data"><i class="icon-basic-water-drop"></i>250g</div>
+    <div class="data ratio-value">1:15.0</div>
+    <div class="equipment mobile">E.g. V60</div>
+  </div>
+  <div class="td row config">
+    <div class="data"><i class="icon-basic-stopwatch-1"></i>02:30</div>
+    <div class="data"><i class="icon-basic-temperature"></i>95</div>
+    <div class="rating mobile">7/10</div>
+  </div>
+  <div class="td rating desktop">7/10</div>
+  <div class="td created">
+    <p><small>2 days ago</small></p>
+  </div>
+</div>

--- a/app/views/dashboard/_no_favourites.html.erb
+++ b/app/views/dashboard/_no_favourites.html.erb
@@ -1,0 +1,74 @@
+<% if current_user.sign_in_count < 5 %>
+  <div class="shelf-item">
+    <div class="coffee-card card column">
+      <h4>This is your Favourites Shelf</h4>
+      <p>The coffees shown here are the ones you have saved as your favourites.</p>
+      <p>Saving favourites is cool. We're planning to do more with favourites later, such as allowing email alerts when one of your favourites becomes available again and recommending new coffees based on your favourites.</p>
+    </div>
+  </div>
+
+  <div id="example_coffee" class="shelf-item">
+    <div class="coffee-card card column">
+      <div class="coffee-card-content row">
+        <div class="column">
+          <h4 class="name"><a class="link link-primary link-title" href="#">Example Coffee</a></h4>
+          <div class="roaster">
+            by <a href="#" class="link link-primary">This Roaster</a>
+            <a class="link link-primary" href="#"><i class="icon-basic-external"></i></a>
+          </div>
+          <ul class="details">
+            <li class="row tasting-notes">
+              <i class="icon-basic-tongue-out"></i> <span>Hazelnut. Black Tea. Red Apple. Dark Chocolate. Raisin Hell. </span>
+            </li>
+            <li class="row country">
+              <i class="icon-basic-location-1"></i>
+              <span>Ethiopia</span>
+            </li>
+            <li class="row process">
+              <i class="icon-basic-factory"></i>
+              <span>Washed</span>
+            </li>
+          </ul>
+        </div>
+        <div class="controls column">
+          <%= render 'shelf_items/shelf_item_toggle', coffee: Coffee.available.first %>
+          <%= render 'favourites/favourite_toggle', coffee: Coffee.available.first %>
+        </div>
+      </div>
+      <div class="footer column">
+        <div class="metadata row">
+          16 brews logged
+        </div>
+        <div class="metadata row">
+        <span class="tooltip-parent">
+          <i class="icon-basic-coffee-cup"></i> 27
+          <span class="tooltip-content bottom delay-fast">Number of Brews</span>
+        </span>
+          <span>&#8226;</span>
+          <span class="tooltip-parent">
+          <i class="icon-basic-shelf"></i> 8
+            <span class="tooltip-content bottom delay-fast">Users with this coffee on their shelf</span>
+        </span>
+          <span>&#8226;</span>
+          <span class="tooltip-parent">
+          <i class="icon-basic-heart"></i> 3
+            <span class="tooltip-content bottom delay-fast">Users who have this saved as a favourite</span>
+        </span>
+          <span>&#8226;</span>
+          <span class="tooltip-parent">
+          <i class="icon-basic-satisfaction"></i> 10
+            <span class="tooltip-content bottom delay-fast">Number of Reviews</span>
+        </span>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<div class="shelf-item">
+  <div class="coffee-card card column">
+    <h3>You don't have any favourite coffees saved yet.</h3>
+    <p>Add a coffee as a favourite to save it here.</p>
+    <h2 class="center"><i class="icon-sl-coffee"></i></h2>
+  </div>
+</div>

--- a/app/views/dashboard/_no_shelf_items.html.erb
+++ b/app/views/dashboard/_no_shelf_items.html.erb
@@ -1,0 +1,43 @@
+<% if current_user.sign_in_count < 5 %>
+  <div class="shelf-item">
+    <div class="coffee-card card column">
+      <h4>This is your Coffee Shelf</h4>
+      <p>Your shelf is where we put the coffees you currently own to keep track of what you have available.</p>
+      <p>A coffee needs to be on your shelf for you to log a brew with it.</p>
+    </div>
+  </div>
+
+  <div id="example_coffee" class="shelf-item">
+    <div class="coffee-card card column">
+      <div class="coffee-card-content row">
+        <div class="column">
+          <h4 class="name"><a class="link link-primary link-title" href="#">Example Coffee</a></h4>
+          <div class="roaster">
+            by <a href="#" class="link link-primary">This Roaster</a>
+            <a class="link link-primary" href="#"><i class="icon-basic-external"></i></a>
+          </div>
+        </div>
+        <div class="controls column">
+          <%= render 'shelf_items/shelf_item_toggle', coffee: Coffee.available.first %>
+          <%= render 'favourites/favourite_toggle', coffee: Coffee.available.first %>
+        </div>
+      </div>
+      <div class="footer column">
+        <div class="metadata row">
+          16 brews logged
+        </div>
+        <div class="brew-btn">
+          <a href="#" class="btn btn-primary btn-primary-border">Make a Brew
+            <i class="icon-basic-coffee-cup-3"></i></a>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<div class="shelf-item">
+  <div class="coffee-card card column">
+    <h2>Your Coffee Shelf is Empty</h2>
+    <p>Add a new coffee to your shelf to start logging your brews</p>
+  </div>
+</div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -36,14 +36,59 @@
       <% @shelf_coffees.reverse.each do |coffee| %>
         <%= render 'shelf_items/shelf_item', coffee: coffee %>
       <% end %>
+      <% unless @shelf_coffees.present? %>
+        <% if current_user.sign_in_count < 5 %>
+          <div class="shelf-item">
+            <div class="coffee-card card column">
+              <h4>This is your Coffee Shelf</h4>
+              <p>Your shelf is where we put the coffees you currently own to keep track of what you have available.</p>
+              <p>A coffee needs to be on your shelf for you to log a brew with it.</p>
+            </div>
+          </div>
 
+          <div id="example_coffee" class="shelf-item">
+            <div class="coffee-card card column">
+              <div class="coffee-card-content row">
+                <div class="column">
+                  <h4 class="name"><a class="link link-primary link-title" href="#">Example Coffee</a></h4>
+                  <div class="roaster">
+                    by <a href="#" class="link link-primary">This Roaster</a>
+                    <a class="link link-primary" href="#"><i class="icon-basic-external"></i></a>
+                  </div>
+                </div>
+                <div class="controls column">
+                  <%= render 'shelf_items/shelf_item_toggle', coffee: Coffee.available.first %>
+                  <%= render 'favourites/favourite_toggle', coffee: Coffee.available.first %>
+                </div>
+              </div>
+              <div class="footer column">
+                <div class="metadata row">
+                  16 brews logged
+                </div>
+                <div class="brew-btn">
+                  <a href="#" class="btn btn-primary btn-primary-border">Make a Brew
+                    <i class="icon-basic-coffee-cup-3"></i></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end %>
+
+        <div class="shelf-item">
+          <div class="coffee-card card column">
+            <h2>Your Coffee Shelf is Empty</h2>
+            <p>Add a new coffee to your shelf to start logging your brews</p>
+          </div>
+        </div>
+      <% end %>
       <div class="shelf-item">
         <div class="coffee-card card column">
           <h4 class="name"><%= link_to "Add New Coffee", coffees_path, class: 'link link-primary link-title' %></h4>
-          <p>Add a new coffee to your shelf by searching for it from the coffees page and clicking the <i class="icon-sl-add"></i> icon.</p>
-          <%#= link_to coffees_path, class: 'btn btn-primary btn-primary-border' do %>
-<!--            Find a Coffee <i class="icon-basic-coffee-bag"></i>-->
-          <%# end %>
+          <p>Add a new coffee to your shelf by searching for it from the coffees page and clicking the
+            <i class="icon-sl-add"></i> icon.</p>
+          <%= link_to coffees_path, class: 'btn btn-primary btn-primary-border' do %>
+            Find a Coffee <i class="icon-basic-coffee-bag"></i>
+          <% end %>
         </div>
       </div>
     </div>
@@ -68,6 +113,5 @@
       <% end %>
     </div>
   </section>
-
 
 </main>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -72,6 +72,19 @@
       <% @favourites.each do |coffee| %>
         <%= render 'favourites/favourite', coffee: coffee %>
       <% end %>
+      <% unless @favourites.present? %>
+        <%= render 'no_favourites' %>
+      <% end %>
+      <div class="shelf-item">
+        <div class="coffee-card card column">
+          <h4 class="name"><%= link_to "Add New Favourite", coffees_path, class: 'link link-primary link-title' %></h4>
+          <p>Add a new favourite coffee by clicking the
+            <i class="icon-basic-heart-1"></i> icon on the coffee card.</p>
+          <%= link_to coffees_path, class: 'btn btn-primary btn-primary-border' do %>
+            Find Your Favourite <i class="icon-sl-coffee"></i>
+          <% end %>
+        </div>
+      </div>
     </div>
   </section>
 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -58,6 +58,9 @@
       <%= turbo_frame_tag 'page_handler' %>
       <div class="brews-table" id="brews_table">
         <%= render 'brews/brews_table', brews: @brews %>
+        <% unless @brews.present? %>
+          <%= render 'no_brews' %>
+        <% end %>
       </div>
       <%= render 'brews_table_pager', pagy: @pagy %>
     </div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -37,49 +37,7 @@
         <%= render 'shelf_items/shelf_item', coffee: coffee %>
       <% end %>
       <% unless @shelf_coffees.present? %>
-        <% if current_user.sign_in_count < 5 %>
-          <div class="shelf-item">
-            <div class="coffee-card card column">
-              <h4>This is your Coffee Shelf</h4>
-              <p>Your shelf is where we put the coffees you currently own to keep track of what you have available.</p>
-              <p>A coffee needs to be on your shelf for you to log a brew with it.</p>
-            </div>
-          </div>
-
-          <div id="example_coffee" class="shelf-item">
-            <div class="coffee-card card column">
-              <div class="coffee-card-content row">
-                <div class="column">
-                  <h4 class="name"><a class="link link-primary link-title" href="#">Example Coffee</a></h4>
-                  <div class="roaster">
-                    by <a href="#" class="link link-primary">This Roaster</a>
-                    <a class="link link-primary" href="#"><i class="icon-basic-external"></i></a>
-                  </div>
-                </div>
-                <div class="controls column">
-                  <%= render 'shelf_items/shelf_item_toggle', coffee: Coffee.available.first %>
-                  <%= render 'favourites/favourite_toggle', coffee: Coffee.available.first %>
-                </div>
-              </div>
-              <div class="footer column">
-                <div class="metadata row">
-                  16 brews logged
-                </div>
-                <div class="brew-btn">
-                  <a href="#" class="btn btn-primary btn-primary-border">Make a Brew
-                    <i class="icon-basic-coffee-cup-3"></i></a>
-                </div>
-              </div>
-            </div>
-          </div>
-        <% end %>
-
-        <div class="shelf-item">
-          <div class="coffee-card card column">
-            <h2>Your Coffee Shelf is Empty</h2>
-            <p>Add a new coffee to your shelf to start logging your brews</p>
-          </div>
-        </div>
+        <%= render 'no_shelf_items' %>
       <% end %>
       <div class="shelf-item">
         <div class="coffee-card card column">

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -36,6 +36,16 @@
       <% @shelf_coffees.reverse.each do |coffee| %>
         <%= render 'shelf_items/shelf_item', coffee: coffee %>
       <% end %>
+
+      <div class="shelf-item">
+        <div class="coffee-card card column">
+          <h4 class="name"><%= link_to "Add New Coffee", coffees_path, class: 'link link-primary link-title' %></h4>
+          <p>Add a new coffee to your shelf by searching for it from the coffees page and clicking the <i class="icon-sl-add"></i> icon.</p>
+          <%#= link_to coffees_path, class: 'btn btn-primary btn-primary-border' do %>
+<!--            Find a Coffee <i class="icon-basic-coffee-bag"></i>-->
+          <%# end %>
+        </div>
+      </div>
     </div>
   </section>
 

--- a/app/views/shelf_items/index.html.erb
+++ b/app/views/shelf_items/index.html.erb
@@ -4,7 +4,7 @@
       <div class="page-title">
         <h2>Your Shelf</h2>
       </div>
-      <% if params["brew_now"] %>
+      <% if params["brew_now"] && @shelf_coffees.present? %>
         <h4 class="title-white">Which coffee are you brewing?</h4>
       <% else %>
         <p>This is where you can keep track of the coffees you currently own. Use the button below to find your coffees,
@@ -21,9 +21,13 @@
       <%= render 'shelf_item', coffee: coffee %>
     <% end %>
 
-    <% if @shelf_coffees.count == 0 %>
+    <% unless @shelf_coffees.present? %>
       <div class="no-coffees">
         <h3>Your Coffee Shelf is Empty</h3>
+        <% if current_user.sign_in_count < 5 %>
+          <p>A coffee needs to be on your shelf for you to log a brew with it.</p>
+          <p>As you're fairly new here, you might want to check out your <%= link_to "dashboard", dashboard_path %>.</p>
+        <% end %>
         <p>Try searching for a <%= link_to "roaster", roasters_path %> or a <%= link_to "coffee", coffees_path %> and
           add it to your shelf</p>
       </div>


### PR DESCRIPTION
# A couple of UX updates, primarily focused on the new user experience. 

Previously, when a new user logged in their dashboard was somewhat empty.
![image](https://user-images.githubusercontent.com/29845460/162420984-4d5128d1-5ee7-4183-b812-582f97bf7e2b.png)

I've added a persistent "add new coffee" card that sits at the end of the coffee shelf.
![image](https://user-images.githubusercontent.com/29845460/162421102-73dbeb7b-2237-4772-975c-2a3caaf2a91e.png)

If the user has no coffees on their shelf then they also see this card:
![image](https://user-images.githubusercontent.com/29845460/162421156-1a72bd21-39ec-430f-88c7-ca4482b76bd9.png)

If they are a "new" user, which I am currerntly classing as having logged in less than 5 times. Then they also see a bit of an explanation as to what the coffee shelf is.
![image](https://user-images.githubusercontent.com/29845460/162421249-0f6242b8-a48f-4241-873e-b699a02b6b8b.png)

Overall this looks like this:
![image](https://user-images.githubusercontent.com/29845460/162421427-23566ac1-95c4-4e57-b226-78fff6948893.png)

I've also done similar work to the brews table and the favourites row:
![image](https://user-images.githubusercontent.com/29845460/162421496-635b5a88-d047-43f1-bbfb-8b41fd0b3ca4.png)

The Shelf Index page has had similar treatment and has gone from this:
![image](https://user-images.githubusercontent.com/29845460/162421744-c8877379-2657-4aae-a9a7-c9e75fc74d65.png)
to this:
![image](https://user-images.githubusercontent.com/29845460/162421775-06429ea2-5397-4e7a-a458-63d54848b056.png)
For new users. Its a small change but just adding more information to help users on their journey.

I've made a small update to the search so that we trim trailing whitespace which can often be added by autocorrect. 